### PR TITLE
Add missing arguments to V[234]_distanceSquared

### DIFF
--- a/Native/MJS.js
+++ b/Native/MJS.js
@@ -337,7 +337,7 @@ Elm.Native.MJS.make = function(elm) {
         return Math.sqrt(dx * dx + dy * dy + dz * dz);
     };
 
-    V3.distanceSquared = function V3_distanceSquared(a) {
+    V3.distanceSquared = function V3_distanceSquared(a, b) {
         var dx = a[0] - b[0];
         var dy = a[1] - b[1];
         var dz = a[2] - b[2];

--- a/Native/Math/Vector2.js
+++ b/Native/Math/Vector2.js
@@ -135,7 +135,7 @@ Elm.Native.Math.Vector2.make = function(elm) {
         return Math.sqrt(dx * dx + dy * dy);
     };
 
-    V2.distanceSquared = function V2_distanceSquared(a) {
+    V2.distanceSquared = function V2_distanceSquared(a, b) {
         var dx = a[0] - b[0];
         var dy = a[1] - b[1];
         return dx * dx + dy * dy;

--- a/Native/Math/Vector4.js
+++ b/Native/Math/Vector4.js
@@ -163,7 +163,7 @@ Elm.Native.Math.Vector4.make = function(elm) {
         return Math.sqrt(dx * dx + dy * dy + dz * dz + dw * dw);
     };
 
-    V4.distanceSquared = function V4_distanceSquared(a) {
+    V4.distanceSquared = function V4_distanceSquared(a, b) {
         var dx = a[0] - b[0];
         var dy = a[1] - b[1];
         var dz = a[2] - b[2];


### PR DESCRIPTION
Calling Math.Vector3.distanceSquared fails with:

```
Uncaught ReferenceError: b is not defined
```

This patch fixes that, and similarly for Vector2 and Vector4.
