### PR TITLE
correct number of arguments for makeOrtho

### DIFF
--- a/src/Math/Matrix4.elm
+++ b/src/Math/Matrix4.elm
@@ -88,7 +88,7 @@ Parameters:
  * znear - the near z distance of the frustum
  * zfar - the far z distance of the frustum
 -}
-makeOrtho : Float -> Float -> Float -> Float -> Float -> Float -> Float -> Mat4
+makeOrtho : Float -> Float -> Float -> Float -> Float -> Float -> Mat4
 makeOrtho = Native.MJS.m4x4makeOrtho
 
 {-| Creates a matrix for a 2D orthogonal frustum projection with the given


### PR DESCRIPTION
Looks like the number of arguments for makeOrtho should be 6 and not 7, which is also consistent with the documentation.
