### PR TITLE
Added support for Mat2 type

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,13 +1,12 @@
 {
-    "version": "1.0.0",
+    "version": "2.0.0",
     "summary": "A linear algebra library for fast vector and matrix math",
     "repository": "https://github.com/johnpmayer/elm-linear-algebra.git",
     "license": "BSD3",
     "source-directories": [
         "src"
     ],
-    "exposed-modules":
-    [
+    "exposed-modules": [
         "Math.Vector2",
         "Math.Vector3",
         "Math.Vector4",

--- a/src/Math/Matrix2.elm
+++ b/src/Math/Matrix2.elm
@@ -1,4 +1,5 @@
 module Math.Matrix2 where
+
 {-| A high performance linear algebra library using native JS arrays. Geared
 towards 3D graphics and use with `Graphics.WebGL`. All vectors are immutable.
 
@@ -21,6 +22,7 @@ existing matrix.
 -}
 
 import Native.Math.Matrix2
+import Math.Vector2 (Vec2)
 
 type Mat2 = Mat2
 
@@ -61,3 +63,22 @@ determinant = Native.Math.Matrix2.m2x2determinant
 -}
 makeRotate : Float -> Mat2
 makeRotate = Native.Math.Matrix2.m2x2makeRotate
+
+{-| Creates a matrix from two Vec2's representing
+the rows of the matrix.
+-}
+fromRows : Vec2 -> Vec2 -> Mat2
+fromRows = Native.Math.Matrix2.m2x2fromRows
+
+
+{-| Creates a matrix from two Vec2's representing
+the columns of the matrix.
+-}
+fromColumns : Vec2 -> Vec2 -> Mat2
+fromColumns = Native.Math.Matrix2.m2x2fromColumns
+
+{-| Converts a 2x2 matrix to a string.
+Useful for printing.
+-}
+toString : Mat2 -> String
+toString = Native.Math.Matrix2.m2x2toString

--- a/src/Math/Matrix2.elm
+++ b/src/Math/Matrix2.elm
@@ -1,0 +1,63 @@
+module Math.Matrix2 where
+{-| A high performance linear algebra library using native JS arrays. Geared
+towards 3D graphics and use with `Graphics.WebGL`. All vectors are immutable.
+
+This library uses the convention that the prefix `make` is creating a new
+array, whereas without the prefix, you are applying some transform to an
+existing matrix.
+
+# Create
+
+@docs identity
+
+# Operations
+
+@docs inverse, mul, add, sub, transpose
+
+# Create Transformations
+
+@docs makeRotate
+
+-}
+
+import Native.Math.Matrix2
+
+type Mat2 = Mat2
+
+{-| A matrix with all 0s, except 1s on the diagonal.
+-}
+identity : Mat2
+identity = Native.Math.Matrix2.m2x2identity
+
+{-| Computes the tranpose of a given matrix.
+-}
+transpose : Mat2 -> Mat2
+transpose = Native.Math.Matrix2.m2x2transpose
+
+{-| Computes the inverse of a given matrix, assuming that the matrix is
+invertible.
+-}
+inverse : Mat2 -> Mat2
+inverse = Native.Math.Matrix2.m2x2inverse
+
+{-| Matrix multiplication: a * b -}
+mul : Mat2 -> Mat2 -> Mat2
+mul = Native.Math.Matrix2.m2x2mul
+
+{-| Matrix addition : a + b -}
+add : Mat2 -> Mat2 -> Mat2
+add = Native.Math.Matrix2.m2x2add
+
+{-| Matrix subtraction : a - b -}
+sub : Mat2 -> Mat2 -> Mat2
+sub = Native.Math.Matrix2.m2x2sub
+
+{-| Computes the determinant of a given matrix.
+-}
+determinant : Mat2 -> Float
+determinant = Native.Math.Matrix2.m2x2determinant
+
+{-| Creates a rotation matrix in radians about the origin.
+-}
+makeRotate : Float -> Mat2
+makeRotate = Native.Math.Matrix2.m2x2makeRotate

--- a/src/Math/Vector2.elm
+++ b/src/Math/Vector2.elm
@@ -101,4 +101,3 @@ scale = Native.Math.Vector2.scale
 {-| The dot product of a and b -}
 dot : Vec2 -> Vec2 -> Float
 dot = Native.Math.Vector2.dot
-

--- a/src/Native/MJS.js
+++ b/src/Native/MJS.js
@@ -312,7 +312,7 @@ Elm.Native.MJS.make = function(elm) {
     };
 
     /*
-     * Function: V3.lengthSquard
+     * Function: V3.lengthSquared
      *
      * Perform r = |a|*|a|.
      *
@@ -1710,7 +1710,7 @@ Elm.Native.MJS.make = function(elm) {
     };
 
     M4x4.makeBasis = function M4x4_makeBasis(vx,vy,vz) {
-        
+
         var r = new MJS_FLOAT_ARRAY_TYPE(16);
 
         r[0] = vx[0];
@@ -1734,7 +1734,7 @@ Elm.Native.MJS.make = function(elm) {
 
     };
 
-    return { 
+    return {
         vec3: F3(V3.$),
         v3getX: V3.getX,
         v3getY: V3.getY,

--- a/src/Native/Math/Matrix2.js
+++ b/src/Native/Math/Matrix2.js
@@ -1,0 +1,265 @@
+Elm.Native.Math = Elm.Native.Math || {};
+Elm.Native.Math.Matrix2 = {};
+Elm.Native.Math.Matrix2.make = function(elm){
+
+  elm.Native = elm.Native || {};
+  elm.Native.Math = elm.Native.Math || {};
+  elm.Native.Math.Matrix2 = elm.Native.Math.Matrix2 || {};
+  if (elm.Native.Math.Matrix2.values) return elm.Native.Math.Matrix2.values;
+
+  var MJS_FLOAT_ARRAY_TYPE = Float32Array;
+
+  var M2x2 = {};
+
+  M2x2._temp1 = new MJS_FLOAT_ARRAY_TYPE(4);
+  M2x2._temp2 = new MJS_FLOAT_ARRAY_TYPE(4);
+
+  if (MJS_FLOAT_ARRAY_TYPE == Array) {
+
+    M2x2.I = [1.0, 0.0,
+              0.0, 1.0];
+
+    M2x2.$ = function M2x2_$(m00, m01,
+                             m02, m03){
+
+      return [m00, m01,
+              m02, m03];
+    };
+
+  } else {
+
+    M2x2.I = new MJS_FLOAT_ARRAY_TYPE([1.0, 0.0,
+                                       0.0, 1.0]);
+
+    /*
+     * Function: M2x2.$
+     *
+     * Creates a new 2x2 matrix with the given values.
+     *
+     * Parameters:
+     *
+     *    m00,m01,m02,m03 - the 4 elements of the new matrix.
+     *
+     * Returns :
+     *
+     *    A new matrix filled with the given argument values.
+     */
+
+    M2x2.$ = function M2x2_$(m00, m01,
+                             m02, m03){
+
+      return new MJS_FLOAT_ARRAY_TYPE([m00, m01,
+                                       m02, m03]);
+    };
+
+  }
+
+  M2x2.identity = M2x2.I;
+
+  /*
+   * Function: M2x2.transpose
+   *
+   * Computes the transpose of the given matrix m.
+   *
+   * Parameters:
+   *
+   *    m - the matrix
+   *    r - optional 2x2 matrix to store the result in
+   *
+   * Returns:
+   *
+   *    If r is specified, returns r after performing the operation.
+   *    Otherwise, returns a new 2x2 matrix with the result.
+   */
+  M2x2.transpose = function M2x2_transpose(m, r){
+
+    if (r == undefined){
+      r = new MJS_FLOAT_ARRAY_TYPE(4);
+    }
+
+    r[0] = m[0];
+    r[1] = m[2];
+    r[2] = m[1]:
+    r[3] = m[3];
+
+    return r;
+  };
+
+  /*
+   * Function: M2x2.inverse
+   *
+   * Computes the inverse of the given matrix m, assuming that
+   * the matrix is invertible.
+   *
+   * Parameters:
+   *
+   *    m - the matrix
+   *    r - optional 2x2 matrix to store the result in
+   *
+   * Returns:
+   *
+   *    If r is specified, returns r after performing the operation.
+   *    Otherwise, returns a new 2x2 matrix with the result.
+   */
+  M2x2.inverse = function M2x2_inverse(m, r){
+
+    if (r == undefined){
+      r = new MJS_FLOAT_ARRAY_TYPE(4);
+    }
+
+    var det = m[0] * m[3] - m[1] * m[2];
+
+    r[0] = m[3] / det;
+    r[1] = -m[1] / det;
+    r[2] = -m[2] / det;
+    r[3] = m[0] / det;
+
+    return r;
+  };
+
+   /*
+    * Function: M2x2.mul
+    *
+    * Performs r = a * b
+    *
+    * Parameters:
+    *
+    *   a - the first matrix operand
+    *   b - the second matrix operand
+    *   r - optional 2x2 matrix to store the result in
+    *
+    * Returns:
+    *
+    *   If r is specified, returns r after performing the operation.
+    *   Otherwise, returns a new 2x2 matrix with the result.
+    */
+  M2x2.mul = function M2x2_mul(a,b,r){
+
+    if (r == undefined){
+      r = new MJS_FLOAT_ARRAY_TYPE(4);
+    }
+
+    r[0] = a[0] * b[0] + a[1] * b[2];
+    r[1] = a[0] * b[1] + a[1] * b[3];
+    r[2] = a[2] * b[0] + a[3] * b[2];
+    r[3] = a[2] * b[1] + a[3] * b[3];
+
+    return r;
+  };
+
+    /*
+    * Function: M2x2.add
+    *
+    * Performs r = a + b
+    *
+    * Parameters:
+    *
+    *   a - the first matrix operand
+    *   b - the second matrix operand
+    *   r - optional 2x2 matrix to store the result in
+    *
+    * Returns:
+    *
+    *   If r is specified, returns r after performing the operation.
+    *   Otherwise, returns a new 2x2 matrix with the result.
+    */
+  M2x2.add = function M2x2_add(a, b, r){
+
+    if (r == undefined){
+      r = new MJS_FLOAT_ARRAY_TYPE(4);
+    }
+
+    r[0] = a[0] + b[0];
+    r[1] = a[1] + b[1];
+    r[2] = a[2] + b[2];
+    r[3] = a[3] + b[3];
+
+    return r;
+  };
+
+    /*
+    * Function: M2x2.sub
+    *
+    * Performs r = a - b
+    *
+    * Parameters:
+    *
+    *   a - the first matrix operand
+    *   b - the second matrix operand
+    *   r - optional 2x2 matrix to store the result in
+    *
+    * Returns:
+    *
+    *   If r is specified, returns r after performing the operation.
+    *   Otherwise, returns a new 2x2 matrix with the result.
+    */
+  M2x2.sub = function M2x2_sub(a,b,r){
+
+    if (r == undefined){
+      r = new MJS_FLOAT_ARRAY_TYPE(4);
+    }
+
+    r[0] = a[0] - b[0];
+    r[1] = a[1] - b[1];
+    r[2] = a[2] - b[2];
+    r[3] = a[3] - b[3];
+
+    return r;
+  };
+
+  /*
+   * Function: M2x2.determinant
+   *
+   * Perform r = det m
+   *
+   * Parameters:
+   *
+   *   m - the matrix
+   *
+   * Returns:
+   *
+   *   The determinant of the given matrix.
+   */
+  M2x2.determinant = function M2x2_determinant(m){
+    return m[0] * m[3] - m[1] * m[2];
+  };
+
+  /*
+   * Function m2x2.makeRotate
+   *
+   * Creates a rotation matrix by angle radians about the origin.
+   *
+   * Parameters:
+   *
+   *   angle - the angle of rotation, in radians
+   *   r - optional 2x2 matrix to store the result in
+   *
+   *   If r is specified, returns r after creating the matrix.
+   *   Otherwise, returns a new 2x2 matrix with the result.
+   */
+  M2x2.makeRotate = function M2x2_makeRotate(angle, r){
+
+    if (r == undefined){
+      r = new MJS_FLOAT_ARRAY_TYPE(4);
+    }
+
+    r[0] = Math.cos(angle);
+    r[1] = -Math.sin(angle);
+    r[2] = -r[1];
+    r[3] = r[0];
+
+    return r;
+  };
+
+  return {
+    m2x2identity: M2x2.identity,
+    m2x2transpose: M2x2.transpose,
+    m2x2inverse : M2x2.inverse,
+    m2x2mul: F2(M2x2.mul),
+    m2x2add: F2(M2x2.add),
+    m2x2sub: F2(M2x2.sub),
+    m2x2determinant: M2x2.determinant,
+    m2x2makeRotate: M2x2.makeRotate
+  };
+
+};

--- a/src/Native/Math/Matrix2.js
+++ b/src/Native/Math/Matrix2.js
@@ -56,6 +56,70 @@ Elm.Native.Math.Matrix2.make = function(elm){
 
   M2x2.identity = M2x2.I;
 
+
+  /*
+   * Function M2x2.fromRows
+   *
+   * Creates a matrix from two 2-d vectors representing the rows
+   * of the created matrix.
+   *
+   * Parameters:
+   *
+   *    row0 - the first or top row of the matrix
+   *    row1 - the second or bottom row of the matrix
+   *    r - optional 2x2 matrix to store the result in
+   *
+   * Returns:
+   *
+   *    If r is specified, returns r after performing the operation.
+   *    Otherwise, returns a new 2x2 matrix with the result.
+   */
+  M2x2.fromRows = function M2x2_fromRows(row0, row1, r){
+    
+    if (r == undefined){
+      r = new MJS_FLOAT_ARRAY_TYPE(4);
+    }
+
+    r[0] = row0[0];
+    r[1] = row0[1];
+    r[2] = row1[0];
+    r[3] = row1[1];
+
+    return r;
+  };
+
+
+  /*
+   * Function M2x2.fromColumns
+   *
+   * Creates a matrix from two 2-d vectors representing the columns
+   * of the created matrix.
+   *
+   * Parameters:
+   *
+   *    column0 - the first or left column of the matrix
+   *    column1 - the second or right column of the matrix
+   *    r - optional 2x2 matrix to store the result in
+   *
+   * Returns:
+   *
+   *    If r is specified, returns r after performing the operation.
+   *    Otherwise, returns a new 2x2 matrix with the result.
+   */
+  M2x2.fromColumns = function M2x2_fromColumns(column0, column1, r){
+
+    if (r == undefined){
+      r = new MJS_FLOAT_ARRAY_TYPE(4);
+    }
+
+    r[0] = column0[0];
+    r[1] = column1[0];
+    r[2] = column0[1];
+    r[3] = column1[1];
+
+    return r;
+  };
+
   /*
    * Function: M2x2.transpose
    *
@@ -79,7 +143,7 @@ Elm.Native.Math.Matrix2.make = function(elm){
 
     r[0] = m[0];
     r[1] = m[2];
-    r[2] = m[1]:
+    r[2] = m[1];
     r[3] = m[3];
 
     return r;
@@ -225,7 +289,7 @@ Elm.Native.Math.Matrix2.make = function(elm){
   };
 
   /*
-   * Function m2x2.makeRotate
+   * Function M2x2.makeRotate
    *
    * Creates a rotation matrix by angle radians about the origin.
    *
@@ -251,15 +315,39 @@ Elm.Native.Math.Matrix2.make = function(elm){
     return r;
   };
 
+
+  /*
+   * Function M2x2.toString
+   *
+   * Converts a 2x2 matrix to a string (useful for printing)
+   *
+   * Parameters :
+   *
+   *    m - the matrix
+   *
+   * Returns :
+   *
+   *    String representation of the input matrix
+   */
+  M2x2.toString = function M2x2_toString(m){
+    var row0 = "[" + m[0].toString() + ", " + m[1].toString() + "]";
+    var row1 = "[" + m[2].toString() + ", " + m[3].toString() + "]";
+
+    return "Mat2 [" + row0 + ", " + row1 + "]";
+  };
+
   return {
     m2x2identity: M2x2.identity,
+    m2x2fromRows: F2(M2x2.fromRows),
+    m2x2fromColumns: F2(M2x2.fromColumns),
     m2x2transpose: M2x2.transpose,
     m2x2inverse : M2x2.inverse,
     m2x2mul: F2(M2x2.mul),
     m2x2add: F2(M2x2.add),
     m2x2sub: F2(M2x2.sub),
     m2x2determinant: M2x2.determinant,
-    m2x2makeRotate: M2x2.makeRotate
+    m2x2makeRotate: M2x2.makeRotate,
+    m2x2toString : M2x2.toString
   };
 
 };

--- a/src/Native/Math/Vector2.js
+++ b/src/Native/Math/Vector2.js
@@ -160,7 +160,35 @@ Elm.Native.Math.Vector2.make = function(elm) {
         return a[0] * b[0] + a[1] * b[1];
     };
 
-    return { 
+    /*
+     * Function: V2.mul2x2
+     *
+     * Performs r = m * v
+     *
+     * Parameters:
+     *
+     *   m - the 2x2 matrix operand
+     *   v - the 2-element vector operand
+     *   r - the optional vector to store the result in
+     *
+     * Returns:
+     *
+     *   If r is specified, returns r after performing the operation.
+     *   Otherwise, returns a new 2-element vector with the result.
+     */
+    V2.mul2x2 = function V2_mul2x2(m, v, r){
+
+        if (r == undefined){
+            r = new MJS_FLOAT_ARRAY_TYPE(2);
+        }
+
+        r[0] = m[0] * v[0] + m[1] * v[1];
+        r[1] = m[2] * v[0] + m[3] * v[1];
+
+        return r;
+    };
+
+    return {
         vec2: F2(V2.$),
         getX: V2.getX,
         getY: V2.getY,
@@ -180,7 +208,8 @@ Elm.Native.Math.Vector2.make = function(elm) {
         distanceSquared: F2(V2.distanceSquared),
         normalize: V2.normalize,
         scale: F2(V2.scale),
-        dot: F2(V2.dot)
+        dot: F2(V2.dot),
+        mul2x2: F2(V2.mul2x2)
     };
 
 };


### PR DESCRIPTION
As promised, here's the extra matrix types. As discussed, I'm splitting the pull requests into smaller requests. This is the PR for Mat2. Once all the details and rough edges (if any) are smoothed I'll send in the PR for Mat3. And then, after that, I'll send in the PR for extra useful functions.

This PR adds support for 2x2 Matrices and comes with the following functions:

**Math/Matrix2.elm**:

``` elm
identity : Mat2
transpose : Mat2 -> Mat2
inverse : Mat2 -> Mat2
mul : Mat2 -> Mat2 -> Mat2
add : Mat2 -> Mat2 -> Mat2
sub : Mat2 -> Mat2 -> Mat2
determinant : Mat2 -> Float
makeRotate : Float -> Mat2
fromRows : Vec2 -> Vec2 -> Mat2
fromColumns : Vec2 -> Vec2 -> Mat2
toString : Mat2 -> String
```

You might notice the `toString` function. I just left it in there in case you wanted it. I needed it to see what I was doing but if you don't want it (or you'd want it modified) I can change it.

I tested the functions a bit and they seemed to give the desired output. Perhaps, you might want to test it yourself to be sure, or perhaps you'd want me to write a whole bunch of unit tests and send them over. I don't know how you do testing, so, if that matters, please tell me, I'd be more than happy to help.

And, by the way, I've tried my best to write the code in the same style as you. If there's anything confusing or in need of re-writing, please tell me.
