### PR TITLE
Fix docs for Vector*.direction

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "2.0.3",
     "summary": "A linear algebra library for fast vector and matrix math",
-    "repository": "https://github.com/johnpmayer/elm-linear-algebra.git",
+    "repository": "https://github.com/nphollon/elm-linear-algebra.git",
     "license": "BSD3",
     "source-directories": [
         "src"

--- a/elm-package.json
+++ b/elm-package.json
@@ -14,7 +14,7 @@
     ],
     "native-modules": true,
     "dependencies": {
-        "elm-lang/core": "2.0.0 <= v < 3.0.0"
+        "elm-lang/core": "3.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.16.0"
+    "elm-version": "0.16.0 <= v < 0.17.0"
 }

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.3",
+    "version": "1.0.0",
     "summary": "A linear algebra library for fast vector and matrix math",
     "repository": "https://github.com/nphollon/elm-linear-algebra.git",
     "license": "BSD3",

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.2",
+    "version": "2.0.3",
     "summary": "A linear algebra library for fast vector and matrix math",
     "repository": "https://github.com/johnpmayer/elm-linear-algebra.git",
     "license": "BSD3",

--- a/src/Math/Vector2.elm
+++ b/src/Math/Vector2.elm
@@ -71,7 +71,7 @@ sub = Native.Math.Vector2.sub
 negate : Vec2 -> Vec2
 negate = Native.Math.Vector2.neg
 
-{-| The normalized direction from a to b: (a - b) / |a - b| -}
+{-| The normalized direction from b to a: (a - b) / |a - b| -}
 direction : Vec2 -> Vec2 -> Vec2
 direction = Native.Math.Vector2.direction
 

--- a/src/Math/Vector3.elm
+++ b/src/Math/Vector3.elm
@@ -92,7 +92,7 @@ sub = Native.MJS.v3sub
 negate : Vec3 -> Vec3
 negate = Native.MJS.v3neg
 
-{-| The normalized direction from a to b: (a - b) / |a - b| -}
+{-| The normalized direction from b to a: (a - b) / |a - b| -}
 direction : Vec3 -> Vec3 -> Vec3
 direction = Native.MJS.v3direction
 

--- a/src/Math/Vector4.elm
+++ b/src/Math/Vector4.elm
@@ -87,7 +87,7 @@ sub = Native.Math.Vector4.sub
 negate : Vec4 -> Vec4
 negate = Native.Math.Vector4.neg
 
-{-| The normalized direction from a to b: (a - b) / |a - b| -}
+{-| The normalized direction from b to a: (a - b) / |a - b| -}
 direction : Vec4 -> Vec4 -> Vec4
 direction = Native.Math.Vector4.direction
 


### PR DESCRIPTION
For the direction functions, I changed "from a to b" to "from b to a". You can check that this is correct by running:

```
import Math.Vector2 exposing (..)
import Graphics.Element exposing (show)

main =
  direction (vec2 0 0) (vec2 0 1)
    |> toRecord |> show
```

And you get:

```
{ x = 0, y = -1 }
```
