### PR TITLE
Update dependencies to run in Elm 0.16.

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.2",
+    "version": "2.0.3",
     "summary": "A linear algebra library for fast vector and matrix math",
     "repository": "https://github.com/johnpmayer/elm-linear-algebra.git",
     "license": "BSD3",
@@ -14,7 +14,7 @@
     ],
     "native-modules": true,
     "dependencies": {
-        "elm-lang/core": "2.0.0 <= v < 3.0.0"
+        "elm-lang/core": "3.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.16.0"
+    "elm-version": "0.16.0 <= v < 0.17.0"
 }


### PR DESCRIPTION
I'm trying to get the examples on elm-lang.org working on elm 0.16. Several depend on WebGL which in turn depends on elm-linear-algebra. So I'm starting here.
